### PR TITLE
sunau raises sunau.Error not wave.Error

### DIFF
--- a/audioread/rawread.py
+++ b/audioread/rawread.py
@@ -66,7 +66,7 @@ class RawAudioFile(object):
 
         try:
             self._file = sunau.open(self._fh)
-        except wave.Error:
+        except sunau.Error:
             # Return to the beginning of the file to try the next reader
             self._fh.seek(0)
             pass


### PR DESCRIPTION
`sunau.open()` raises `sunau.Error`, not `wave.Error`. Without this fix I get the following error when attempting to open an MP3 file:

``` python
Python 2.7.8 (default, Oct 19 2014, 16:02:00)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.54)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import audioread
>>> audioread.audio_open("test.mp3")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "audioread/__init__.py", line 60, in audio_open
    return rawread.RawAudioFile(path)
  File "audioread/rawread.py", line 68, in __init__
    self._file = sunau.open(self._fh)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sunau.py", line 487, in open
    return Au_read(f)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sunau.py", line 158, in __init__
    self.initfp(f)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sunau.py", line 169, in initfp
    raise Error, 'bad magic number'
sunau.Error: bad magic number
>>>
```
