### PR TITLE
Compressed audio (continuation of #36)

### DIFF
--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -68,45 +68,60 @@ def _mad_available():
         return True
 
 
-def audio_open(path=None, audio=None):
+def audio_open(path):
     """Open an audio file using a library that is available on this
     system.
     """
     # Standard-library WAV and AIFF readers.
-    #from . import rawread
-    #try:
-    #    return rawread.RawAudioFile(path)
-    #except DecodeError:
-    #    pass
+    from . import rawread
+    try:
+        return rawread.RawAudioFile(path)
+    except DecodeError:
+        pass
 
     # Core Audio.
-    #if _ca_available():
-    #    from . import macca
-    #    try:
-    #        return macca.ExtAudioFile(path)
-    #    except DecodeError:
-    #        pass
+    if _ca_available():
+        from . import macca
+        try:
+            return macca.ExtAudioFile(path)
+        except DecodeError:
+            pass
 
     # GStreamer.
-    #if _gst_available():
-    #    from . import gstdec
-    #    try:
-    #        return gstdec.GstAudioFile(path)
-    #    except DecodeError:
-    #        pass
+    if _gst_available():
+        from . import gstdec
+        try:
+            return gstdec.GstAudioFile(path)
+        except DecodeError:
+            pass
 
     # MAD.
-    #if _mad_available():
-    #    from . import maddec
-    #    try:
-    #        return maddec.MadAudioFile(path)
-    #    except DecodeError:
-    #        pass
+    if _mad_available():
+        from . import maddec
+        try:
+            return maddec.MadAudioFile(path)
+        except DecodeError:
+            pass
 
     # FFmpeg.
     from . import ffdec
     try:
-        return ffdec.FFmpegAudioFile(path,audio)
+        return ffdec.FFmpegAudioFile(path)
+    except DecodeError:
+        pass
+
+    # All backends failed!
+    raise NoBackendError()
+
+
+def decode(audio):
+    """Given a file-like object containing encoded audio data, create an
+    audio file object that produces its *raw* data.
+    """
+    # FFmpeg.
+    from . import ffdec
+    try:
+        return ffdec.FFmpegAudioFile(audio=audio)
     except DecodeError:
         pass
 

--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -68,45 +68,45 @@ def _mad_available():
         return True
 
 
-def audio_open(path):
+def audio_open(path=None, audio=None):
     """Open an audio file using a library that is available on this
     system.
     """
     # Standard-library WAV and AIFF readers.
-    from . import rawread
-    try:
-        return rawread.RawAudioFile(path)
-    except DecodeError:
-        pass
+    #from . import rawread
+    #try:
+    #    return rawread.RawAudioFile(path)
+    #except DecodeError:
+    #    pass
 
     # Core Audio.
-    if _ca_available():
-        from . import macca
-        try:
-            return macca.ExtAudioFile(path)
-        except DecodeError:
-            pass
+    #if _ca_available():
+    #    from . import macca
+    #    try:
+    #        return macca.ExtAudioFile(path)
+    #    except DecodeError:
+    #        pass
 
     # GStreamer.
-    if _gst_available():
-        from . import gstdec
-        try:
-            return gstdec.GstAudioFile(path)
-        except DecodeError:
-            pass
+    #if _gst_available():
+    #    from . import gstdec
+    #    try:
+    #        return gstdec.GstAudioFile(path)
+    #    except DecodeError:
+    #        pass
 
     # MAD.
-    if _mad_available():
-        from . import maddec
-        try:
-            return maddec.MadAudioFile(path)
-        except DecodeError:
-            pass
+    #if _mad_available():
+    #    from . import maddec
+    #    try:
+    #        return maddec.MadAudioFile(path)
+    #    except DecodeError:
+    #        pass
 
     # FFmpeg.
     from . import ffdec
     try:
-        return ffdec.FFmpegAudioFile(path)
+        return ffdec.FFmpegAudioFile(path,audio)
     except DecodeError:
         pass
 

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -22,7 +22,6 @@ import re
 import threading
 import time
 import os
-from cStringIO import StringIO
 try:
     import queue
 except ImportError:
@@ -58,7 +57,7 @@ class NoInputError(FFmpegError):
 class QueueReaderThread(threading.Thread):
     """A thread that consumes data from a filehandle and sends the data
     over a Queue.
-     """
+    """
     def __init__(self, fh, blocksize=1024, discard=False):
         super(QueueReaderThread, self).__init__()
         self.fh = fh
@@ -70,7 +69,6 @@ class QueueReaderThread(threading.Thread):
     def run(self):
         while True:
             data = self.fh.read(self.blocksize)
-            #print data
             if not self.discard:
                 self.queue.put(data)
             if not data:
@@ -135,7 +133,7 @@ class FFmpegAudioFile(object):
             ctypes.windll.kernel32.SetErrorMode(
                 previous_error_mode | SEM_NOGPFAULTERRORBOX
             )
-        
+
         try:
             if self.openFile:
                 self.devnull = open(os.devnull)
@@ -176,12 +174,12 @@ class FFmpegAudioFile(object):
         if self.readAudio:
             self.stdin_writer = WriterThread(self.proc.stdin,audio)
             self.stdin_writer.start()
-        
+
         # Start another thread to consume the standard output of the
         # process, which contains raw audio data.
         self.stdout_reader = QueueReaderThread(self.proc.stdout, block_size)
         self.stdout_reader.start()
-        
+
         # Read relevant information from stderr.
         self._get_info()
 
@@ -201,7 +199,6 @@ class FFmpegAudioFile(object):
             data = None
             try:
                 data = self.stdout_reader.queue.get(timeout=timeout)
-                
                 if data:
                     yield data
                 else:
@@ -229,7 +226,6 @@ class FFmpegAudioFile(object):
         out_parts = []
         while True:
             line = self.proc.stderr.readline()
-
             if not line:
                 # EOF and data not found.
                 raise CommunicationError("stream info not found")

--- a/decode.py
+++ b/decode.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # This file is part of audioread.
 # Copyright 2011, Adrian Sampson.
 #
@@ -28,7 +30,7 @@ def decode(filename):
         sys.exit(1)
 
     try:
-        with audioread.audio_open(filename) as f:
+        with audioread.audio_open(audio=open(filename,"r")) as f:
             print('Input file: %i channels at %i Hz; %.1f seconds.' %
                   (f.channels, f.samplerate, f.duration),
                   file=sys.stderr)

--- a/decode.py
+++ b/decode.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # This file is part of audioread.
 # Copyright 2011, Adrian Sampson.
 #
@@ -30,7 +28,7 @@ def decode(filename):
         sys.exit(1)
 
     try:
-        with audioread.audio_open(audio=open(filename,"r")) as f:
+        with audioread.audio_open(filename) as f:
             print('Input file: %i channels at %i Hz; %.1f seconds.' %
                   (f.channels, f.samplerate, f.duration),
                   file=sys.stderr)


### PR DESCRIPTION
This is @jksinton's work on making the FFmpeg backend work on data from a stream instead of from disk.

I changed around the top-level interface a bit. There's a new `audioread.decode` function that works on streams instead of filenames. The included demo script, `decode.py`, can now work on data from stdin. So this works, for example:

    $ python decode.py < foo.mp3

and produces a WAV file in `out.wav`. (Eventually, it would be nice to write that to stdout too to demonstrate that we're actually streaming!)