### PR TITLE
Decoding 8-bit wave files: not handled as 8-bit unsigned ints  

### DIFF
--- a/audioread/rawread.py
+++ b/audioread/rawread.py
@@ -109,6 +109,9 @@ class RawAudioFile(object):
                 break
 
             # Make sure we have the desired bitdepth and endianness.
+            if old_width == 1:
+                # unsigned int => signed int
+                data = audioop.bias(data, old_width, 128)
             data = audioop.lin2lin(data, old_width, TARGET_WIDTH)
             if self._needs_byteswap and self._file.getcomptype() != 'sowt':
                 # Big-endian data. Swap endianness.


### PR DESCRIPTION
8-bit wave files are unsigned ints, 0 to 255. Values need to be offset by 128 to shift the range to that of a signed int, -128 to 127, as noted in the [Python audioop docs](https://docs.python.org/3.5/library/audioop.html#audioop.lin2lin).

This then allows, for example, calling / client code to safely convert decoded frames to floats in the range -1.0 to 1.0, as all bit depths can be handled them same (dividing by 2^bit_width-1). 