### PR TITLE
audioread/ffdec.py: fix parsing for multiple channels

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -231,9 +231,9 @@ class FFmpegAudioFile(object):
             if mode == 'stereo':
                 self.channels = 2
             else:
-                match = re.match(r'(\d+) ', mode)
-                if match:
-                    self.channels = int(match.group(1))
+                cmatch = re.match(r'(\d).?(\d)?', mode)
+                if cmatch:
+                    self.channels = sum(map(int, cmatch.group().split('.')))
                 else:
                     self.channels = 1
         else:

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -231,7 +231,7 @@ class FFmpegAudioFile(object):
             if mode == 'stereo':
                 self.channels = 2
             else:
-                cmatch = re.match(r'(\d).?(\d)?', mode)
+                cmatch = re.match(r'(\d+)\.?(\d)?', mode)
                 if cmatch:
                     self.channels = sum(map(int, cmatch.group().split('.')))
                 else:


### PR DESCRIPTION
 - change regex to also look for N.M, e.g. 2.1
 - compute the sum of all matches to find real channel count
 - avoid overwriting local variable
 - see also librosa/librosa#523