### PR TITLE
added __version__; fixes #49

### DIFF
--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -14,6 +14,8 @@
 
 """Decode audio files."""
 
+from .version import version as __version__
+
 
 class DecodeError(Exception):
     """The base exception class for all decoding errors raised by this

--- a/audioread/version.py
+++ b/audioread/version.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+'''Version information'''
+
+version = '2.1.5pre'
+short_version = '2.1'

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@
 
 import os
 from distutils.core import setup
+import imp
+
+version = imp.load_source('audioread.version', 'audioread/version.py')
 
 
 def _read(fn):
@@ -22,7 +25,7 @@ def _read(fn):
 
 
 setup(name='audioread',
-      version='2.1.5',
+      version=version.version,
       description='multi-library, cross-platform audio decoding',
       author='Adrian Sampson',
       author_email='adrian@radbox.org',


### PR DESCRIPTION
This PR adds `__version__` to `audioread` and restructures the setup script to pull the version number from the source.

I took the liberty of initializing the version number to `2.1.5pre`, since 2.1.4 is already out the door.

I did not add tests for this, but it does work locally.