### PR TITLE
robust way of locating ffmpeg on system

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -28,8 +28,9 @@ except ImportError:
     import Queue as queue
 
 from . import DecodeError
+from imageio.plugins.ffmpeg import get_exe
 
-COMMANDS = ('ffmpeg', 'avconv')
+COMMANDS = (get_exe(), 'avconv')
 
 
 class FFmpegError(DecodeError):


### PR DESCRIPTION
On line 32 in /ffdec.py, you are assuming that ffmpeg is already in system path. 

I have a better way of locating ffmpeg. I found it in **[Moviepy](https://github.com/Zulko/moviepy)** library.

**from imageio.plugins.ffmpeg import get_exe** -->Imageio helps to get the absolute path of ffmpeg

Hope this helps!

Tejas