### PR TITLE
Fixes `subprocess` exception on WSL

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -258,6 +258,12 @@ class FFmpegAudioFile(object):
 
     def close(self):
         """Close the ffmpeg process used to perform the decoding."""
+        # Check the process's execution status before attempting to kill it.
+        # This fixes an issue on Windows Subsystem for Linux where ffmpeg
+        # closes normally on its own, but never updates `returncode`.
+        if hasattr(self, 'proc'):
+            self.proc.poll()
+
         # Kill the process if it is still running.
         if hasattr(self, 'proc') and self.proc.returncode is None:
             self.proc.kill()

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -258,17 +258,16 @@ class FFmpegAudioFile(object):
 
     def close(self):
         """Close the ffmpeg process used to perform the decoding."""
-        # Check the process's execution status before attempting to kill it.
-        # This fixes an issue on Windows Subsystem for Linux where ffmpeg
-        # closes normally on its own, but never updates `returncode`.
-        if hasattr(self, 'proc'):
-            self.proc.poll()
-
         # Kill the process if it is still running.
-        if hasattr(self, 'proc') and self.proc.returncode is None:
-            self.proc.kill()
-            self.proc.wait()
-            self.devnull.close()
+        if hasattr(self, 'proc'):
+            # Check the process's execution status before attempting to kill it.
+            # This fixes an issue on Windows Subsystem for Linux where ffmpeg
+            # closes normally on its own, but never updates `returncode`.
+            self.proc.poll()
+            if self.proc.returncode is None:
+                self.proc.kill()
+                self.proc.wait()
+                self.devnull.close()
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
This fixes issue #51 regarding `self.proc.kill()` when running on Windows Subsystem for Linux.
On WSL, ffmpeg is terminating normally, but `returncode` isn't being updated.  Calling `poll()` on the subprocess returns immediately and forces an update of `returncode`.  This allows the code to skip the `kill()` call if the process is already done.