### PR TITLE
Close file handles in ffdec.py

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -264,12 +264,14 @@ class FFmpegAudioFile(object):
             # ffmpeg closes normally on its own, but never updates
             # `returncode`.
             self.proc.poll()
+            self.proc.stdout.close()
+            self.proc.stderr.close()
 
             # Kill the process if it is still running.
             if self.proc.returncode is None:
                 self.proc.kill()
                 self.proc.wait()
-                self.devnull.close()
+        self.devnull.close()
 
     def __del__(self):
         self.close()

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -264,6 +264,8 @@ class FFmpegAudioFile(object):
             # ffmpeg closes normally on its own, but never updates
             # `returncode`.
             self.proc.poll()
+
+            # Close the stdout and stderr streams that were opened by Popen.
             self.proc.stdout.close()
             self.proc.stderr.close()
 
@@ -271,6 +273,9 @@ class FFmpegAudioFile(object):
             if self.proc.returncode is None:
                 self.proc.kill()
                 self.proc.wait()
+
+        # Close the handle to os.devnull, which is opened regardless of if
+        # a subprocess is successfully created
         self.devnull.close()
 
     def __del__(self):

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -265,7 +265,9 @@ class FFmpegAudioFile(object):
             # `returncode`.
             self.proc.poll()
 
-            # Close the stdout and stderr streams that were opened by Popen.
+            # Close the stdout and stderr streams that were opened by Popen,
+            # which should occur regardless of if the process terminated
+            # cleanly.
             self.proc.stdout.close()
             self.proc.stderr.close()
 


### PR DESCRIPTION
Hello!

Thanks for all the hard work putting this library together! It made quickly combining two audio files I had super easy.

This PR just closes the /dev/null, stdout, and stderr FDs when in FFmpeg mode to avoid resource leak warnings.

Let me know if there are any issues,

Ryan