### PR TITLE
maddec: Ensure that the audio blocks are of type bytes()

### DIFF
--- a/audioread/maddec.py
+++ b/audioread/maddec.py
@@ -43,7 +43,7 @@ class MadAudioFile(object):
             out = self.mf.read(block_size)
             if not out:
                 break
-            yield out
+            yield bytes(out)
 
     @property
     def samplerate(self):


### PR DESCRIPTION
The audio blocks should be bytes() to be consistent with the other
decoders.

This is required for the pyacoustid and chromaprint libraries, and fixes
the following backtrace in Beets when using the 'chroma' plugin:

    Traceback (most recent call last):
      File "/usr/bin/beet", line 11, in <module>
        load_entry_point('beets==1.4.6', 'console_scripts', 'beet')()
      File "/usr/lib/python3.6/site-packages/beets/ui/__init__.py", line 1256, in main
        _raw_main(args)
      File "/usr/lib/python3.6/site-packages/beets/ui/__init__.py", line 1243, in _raw_main
        subcommand.func(lib, suboptions, subargs)
      File "/usr/lib/python3.6/site-packages/beets/ui/commands.py", line 937, in import_func
        import_files(lib, paths, query)
      File "/usr/lib/python3.6/site-packages/beets/ui/commands.py", line 914, in import_files
        session.run()
      File "/usr/lib/python3.6/site-packages/beets/importer.py", line 327, in run
        pl.run_parallel(QUEUE_SIZE)
      File "/usr/lib/python3.6/site-packages/beets/util/pipeline.py", line 445, in run_parallel
        six.reraise(exc_info[0], exc_info[1], exc_info[2])
      File "/usr/lib/python3.6/site-packages/six.py", line 693, in reraise
        raise value
      File "/usr/lib/python3.6/site-packages/beets/util/pipeline.py", line 312, in run
        out = self.coro.send(msg)
      File "/usr/lib/python3.6/site-packages/beets/util/pipeline.py", line 194, in coro
        func(*(args + (task,)))
      File "/usr/lib/python3.6/site-packages/beets/importer.py", line 1339, in lookup_candidates
        plugins.send('import_task_start', session=session, task=task)
      File "/usr/lib/python3.6/site-packages/beets/plugins.py", line 452, in send
        result = handler(**arguments)
      File "/usr/lib/python3.6/site-packages/beets/plugins.py", line 124, in wrapper
        return func(*args, **kwargs)
      File "/usr/lib/python3.6/site-packages/beetsplug/chroma.py", line 143, in fingerprint_task
        return fingerprint_task(self._log, task, session)
      File "/usr/lib/python3.6/site-packages/beetsplug/chroma.py", line 212, in fingerprint_task
        acoustid_match(log, item.path)
      File "/usr/lib/python3.6/site-packages/beetsplug/chroma.py", line 65, in acoustid_match
        duration, fp = acoustid.fingerprint_file(util.syspath(path))
      File "/usr/lib/python3.6/site-packages/acoustid.py", line 321, in fingerprint_file
        return _fingerprint_file_audioread(path, maxlength)
      File "/usr/lib/python3.6/site-packages/acoustid.py", line 264, in _fingerprint_file_audioread
        fp = fingerprint(f.samplerate, f.channels, iter(f), maxlength)
      File "/usr/lib/python3.6/site-packages/acoustid.py", line 206, in fingerprint
        fper.feed(block)
      File "/usr/lib/python3.6/site-packages/chromaprint.py", line 126, in feed
        self._ctx, data, len(data) // 2
    ctypes.ArgumentError: argument 2: <class 'TypeError'>: wrong type