### PR TITLE
ffdec: Stop the ffmpeg process before closing any buffers

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -265,16 +265,17 @@ class FFmpegAudioFile(object):
             # `returncode`.
             self.proc.poll()
 
+            # Kill the process if it is still running.
+            if self.proc.returncode is None:
+                self.proc.kill()
+                self.proc.wait()
+
             # Close the stdout and stderr streams that were opened by Popen,
             # which should occur regardless of if the process terminated
             # cleanly.
             self.proc.stdout.close()
             self.proc.stderr.close()
 
-            # Kill the process if it is still running.
-            if self.proc.returncode is None:
-                self.proc.kill()
-                self.proc.wait()
 
         # Close the handle to os.devnull, which is opened regardless of if
         # a subprocess is successfully created.


### PR DESCRIPTION
This fixes intermittent crashes that were introduced by commit
ac7b1e07ea47a1ebfc.

In some situations the .close() method is called before the child
process has completed. If we close proc.stderr and proc.stdout while
a QueueReaderThread instance is still running, we get errors such as
this:

    Exception in thread Thread-2:
    Traceback (most recent call last):
      File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
        self.run()
      File "/home/sam/src/audioread/audioread/ffdec.py", line 73, in run
        data = self.fh.read(self.blocksize)
    ValueError: I/O operation on closed file

Sometimes the CPython interpreter segfaults inside the io.read() call
before it can show this error.

We now kill the child process and wait for it to terminate before
closing the stdout and stderr pipes. This gives the queue reader threads
time to receive the end-of-file notifications from the pipes while they
are still open.