### PR TITLE
ffdec: Ensure that QueueReaderThreads have stopped before closing pipes

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -270,6 +270,9 @@ class FFmpegAudioFile(object):
                 self.proc.kill()
                 self.proc.wait()
 
+            self.stderr_reader.join()
+            self.stdout_reader.join()
+
             # Close the stdout and stderr streams that were opened by Popen,
             # which should occur regardless of if the process terminated
             # cleanly.


### PR DESCRIPTION
This is a follow up from 8d10f7b (https://github.com/beetbox/audioread/pull/78)

The previous fix was enough to stop my test case from crashing, but when
running `beet import` the problem would still occur.