### PR TITLE
ffdec: Avoid AttributeError during destruction

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -272,8 +272,10 @@ class FFmpegAudioFile(object):
 
             # Wait for the stream-reading threads to exit. (They need to
             # stop reading before we can close the streams.)
-            self.stderr_reader.join()
-            self.stdout_reader.join()
+            if hasattr(self, 'stderr_reader'):
+                self.stderr_reader.join()
+            if hasattr(self, 'stdout_reader'):
+                self.stdout_reader.join()
 
             # Close the stdout and stderr streams that were opened by Popen,
             # which should occur regardless of if the process terminated


### PR DESCRIPTION
This fixes a possible exception that looks like this:

    Traceback (most recent call last):
      File "/home/sam/src/audioread/audioread/ffdec.py", line 305, in __del__
        self.close()
      File "/home/sam/src/audioread/audioread/ffdec.py", line 290, in close
        self.stderr_reader.join()
    AttributeError: 'FFmpegAudioFile' object has no attribute 'stderr_reader'

The close() method is called from this object's destructor, so it has to
be handle being called with the object in any state.