### PR TITLE
Only run backend autodetection once per process

### DIFF
--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -70,6 +70,12 @@ def _mad_available():
         return True
 
 
+def _ffmpeg_available():
+    """Determines whether the ffmpeg program is available."""
+    from . import ffdec
+    return ffdec.available()
+
+
 def audio_open(path):
     """Open an audio file using a library that is available on this
     system.

--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -15,18 +15,8 @@
 """Decode audio files."""
 
 from . import ffdec
+from .exceptions import DecodeError, NoBackendError
 from .version import version as __version__  # noqa
-
-class DecodeError(Exception):
-    """The base exception class for all decoding errors raised by this
-    package.
-    """
-
-
-class NoBackendError(DecodeError):
-    """The file could not be decoded by any backend. Either no backends
-    are available or each available backend failed to decode the file.
-    """
 
 
 def _gst_available():

--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -14,8 +14,8 @@
 
 """Decode audio files."""
 
+from . import ffdec
 from .version import version as __version__  # noqa
-
 
 class DecodeError(Exception):
     """The base exception class for all decoding errors raised by this
@@ -70,12 +70,6 @@ def _mad_available():
         return True
 
 
-def _ffmpeg_available():
-    """Determines whether the ffmpeg program is available."""
-    from . import ffdec
-    return ffdec.available()
-
-
 def available_backends():
     """Returns a list of backends that are available on this system."""
 
@@ -99,8 +93,7 @@ def available_backends():
         result.append(maddec.MadAudioFile)
 
     # FFmpeg.
-    if _ffmpeg_available():
-        from . import ffdec
+    if ffdec.available():
         result.append(ffdec.FFmpegAudioFile)
 
     return result

--- a/audioread/exceptions.py
+++ b/audioread/exceptions.py
@@ -1,0 +1,25 @@
+# This file is part of audioread.
+# Copyright 2013, Adrian Sampson.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+
+class DecodeError(Exception):
+    """The base exception class for all decoding errors raised by this
+    package.
+    """
+
+
+class NoBackendError(DecodeError):
+    """The file could not be decoded by any backend. Either no backends
+    are available or each available backend failed to decode the file.
+    """

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -102,10 +102,7 @@ def available():
         stderr=subprocess.PIPE,
     )
     proc.wait()
-    if proc.returncode == 0:
-        return True
-    else:
-        return False
+    return (proc.returncode == 0)
 
 
 # For Windows error switch management, we need a lock to keep the mode

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -93,6 +93,21 @@ def popen_multiple(commands, command_args, *args, **kwargs):
                 raise
 
 
+def available():
+    """Detect if the FFmpeg backend can be used on this system."""
+    proc = popen_multiple(
+        COMMANDS,
+        ['-version'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    proc.wait()
+    if proc.returncode == 0:
+        return True
+    else:
+        return False
+
+
 # For Windows error switch management, we need a lock to keep the mode
 # adjustment atomic.
 windows_error_mode_lock = threading.Lock()

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     import Queue as queue
 
-from . import DecodeError
+from .exceptions import DecodeError
 
 COMMANDS = ('ffmpeg', 'avconv')
 

--- a/audioread/gstdec.py
+++ b/audioread/gstdec.py
@@ -55,7 +55,8 @@ from gi.repository import GLib, Gst
 import sys
 import threading
 import os
-from . import DecodeError
+
+from .exceptions import DecodeError
 
 try:
     import queue

--- a/audioread/macca.py
+++ b/audioread/macca.py
@@ -18,7 +18,8 @@ import sys
 import ctypes
 import ctypes.util
 import copy
-from . import DecodeError
+
+from .exceptions import DecodeError
 
 
 # CoreFoundation and CoreAudio libraries along with their function

--- a/audioread/rawread.py
+++ b/audioread/rawread.py
@@ -19,7 +19,8 @@ import sunau
 import audioop
 import struct
 import sys
-from . import DecodeError
+
+from .exceptions import DecodeError
 
 # Produce two-byte (16-bit) output samples.
 TARGET_WIDTH = 2


### PR DESCRIPTION
This is a performance improvement. See https://github.com/beetbox/audioread/issues/81 for details.