### PR TITLE
Better subprocess error handling

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -87,7 +87,7 @@ def popen_multiple(commands, command_args, *args, **kwargs):
         cmd = [command] + command_args
         try:
             return subprocess.Popen(cmd, *args, **kwargs)
-        except OSError:
+        except (OSError, subprocess.CalledProcessError):
             if i == len(commands) - 1:
                 # No more commands to try.
                 raise
@@ -100,6 +100,7 @@ def available():
         ['-version'],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        creationflags=subprocess.CREATE_NO_WINDOW
     )
     proc.wait()
     return (proc.returncode == 0)
@@ -137,6 +138,7 @@ class FFmpegAudioFile(object):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=self.devnull,
+                creationflags=subprocess.CREATE_NO_WINDOW
             )
 
         except OSError:

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -99,8 +99,7 @@ def available():
         COMMANDS,
         ['-version'],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        creationflags=subprocess.CREATE_NO_WINDOW
+        stderr=subprocess.PIPE
     )
     proc.wait()
     return (proc.returncode == 0)
@@ -137,8 +136,7 @@ class FFmpegAudioFile(object):
                 ['-i', filename, '-f', 's16le', '-'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                stdin=self.devnull,
-                creationflags=subprocess.CREATE_NO_WINDOW
+                stdin=self.devnull
             )
 
         except OSError:


### PR DESCRIPTION
The console window which opens every time when accessing ffmpeg sucks. This PR will stop this behaviour.
Additionally also subprocess.CalledProcessErrors are catched.