### PR TITLE
Don't open a window when supported

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -86,11 +86,17 @@ def popen_multiple(commands, command_args, *args, **kwargs):
     for i, command in enumerate(commands):
         cmd = [command] + command_args
         try:
-            return subprocess.Popen(cmd, *args, **kwargs)
+            if hasattr(subprocess, "CREATE_NO_WINDOW"):
+                process = subprocess.Popen(cmd, *args, creationflags= \
+                                           subprocess.CREATE_NO_WINDOW,
+                                           **kwargs)
+            else:
+                process = subprocess.Popen(cmd, *args, **kwargs)
         except OSError:
             if i == len(commands) - 1:
                 # No more commands to try.
                 raise
+        return process
 
 
 def available():
@@ -99,7 +105,7 @@ def available():
         COMMANDS,
         ['-version'],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
     proc.wait()
     return (proc.returncode == 0)
@@ -136,7 +142,7 @@ class FFmpegAudioFile(object):
                 ['-i', filename, '-f', 's16le', '-'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                stdin=self.devnull,
+                stdin=self.devnull
             )
 
         except OSError:

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -105,7 +105,7 @@ def available():
         COMMANDS,
         ['-version'],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
     )
     proc.wait()
     return (proc.returncode == 0)
@@ -142,7 +142,7 @@ class FFmpegAudioFile(object):
                 ['-i', filename, '-f', 's16le', '-'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                stdin=self.devnull
+                stdin=self.devnull,
             )
 
         except OSError:

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -31,6 +31,11 @@ from .exceptions import DecodeError
 
 COMMANDS = ('ffmpeg', 'avconv')
 
+if sys.platform == "win32":
+    PROC_FLAGS = 0x08000000
+else:
+    PROC_FLAGS = 0
+
 
 class FFmpegError(DecodeError):
     pass
@@ -86,17 +91,11 @@ def popen_multiple(commands, command_args, *args, **kwargs):
     for i, command in enumerate(commands):
         cmd = [command] + command_args
         try:
-            if hasattr(subprocess, "CREATE_NO_WINDOW"):
-                process = subprocess.Popen(cmd, *args, creationflags= \
-                                           subprocess.CREATE_NO_WINDOW,
-                                           **kwargs)
-            else:
-                process = subprocess.Popen(cmd, *args, **kwargs)
+            return subprocess.Popen(cmd, *args, **kwargs)
         except OSError:
             if i == len(commands) - 1:
                 # No more commands to try.
                 raise
-        return process
 
 
 def available():
@@ -106,6 +105,7 @@ def available():
         ['-version'],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        creationflags=PROC_FLAGS,
     )
     proc.wait()
     return (proc.returncode == 0)
@@ -143,6 +143,7 @@ class FFmpegAudioFile(object):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=self.devnull,
+                creationflags=PROC_FLAGS,
             )
 
         except OSError:


### PR DESCRIPTION
The console window which opens every time when accessing ffmpeg sucks. This PR will stop this behaviour when it's supported by the Python version ([introduced](https://docs.python.org/3/library/subprocess.html?highlight=subprocess#subprocess.CREATE_NO_WINDOW) in 3.7)

Successor of #88.