### PR TITLE
Correct pytest-runner location in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,8 @@ setup(name='audioread',
 
       packages=['audioread'],
 
-      setup_requires=[
-          'pytest-runner'
-      ],
-
       tests_require=[
+          'pytest-runner',
           'pytest'
       ],
 


### PR DESCRIPTION
Moved pytest-runner from setup_requires to tests_require.  It is the tests that require pytest-runner.