### PR TITLE
Modify MANIFEST.in to include full test bundle

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include README.rst
 include decode.py
 # License
 include LICENSE
+# Include full test suite
+recursive-include test/ *


### PR DESCRIPTION
This will include the full test bundle on PyPI.

In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.