### PR TITLE
gstdec: Update in line with GStreamer 1.18 API break

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,9 @@ convert compressed audio files to WAV files.
 Version History
 ---------------
 
+2.1.9
+  Work correctly with GStreamer 1.18 and later (thanks to @ssssam)
+
 2.1.8
   Fix an unhandled ``OSError`` when FFmpeg is not installed.
 

--- a/audioread/gstdec.py
+++ b/audioread/gstdec.py
@@ -321,7 +321,14 @@ class GstAudioFile(object):
             mem = buf.get_all_memory()
             success, info = mem.map(Gst.MapFlags.READ)
             if success:
-                data = info.data
+                if isinstance(info.data, memoryview):
+                    # We need to copy the data as the memoryview is released
+                    # when we call mem.unmap()
+                    data = bytes(info.data)
+                else:
+                    # GStreamer Python bindings <= 1.16 return a copy of the
+                    # data as bytes()
+                    data = info.data
                 mem.unmap(info)
                 self.queue.put(data)
             else:


### PR DESCRIPTION
This fixes an issue seen when calculating fingerprints with GStreamer
1.18:

      ...
      File "/usr/lib/python3.9/site-packages/acoustid.py", line 333, in fingerprint_file
        return _fingerprint_file_audioread(path, maxlength)
      File "/usr/lib/python3.9/site-packages/acoustid.py", line 275, in _fingerprint_file_audioread
        fp = fingerprint(f.samplerate, f.channels, iter(f), maxlength)
      File "/usr/lib/python3.9/site-packages/acoustid.py", line 217, in fingerprint
        fper.feed(block)
      File "/usr/lib/python3.9/site-packages/chromaprint.py", line 145, in feed
        data = BYTES_TYPE(data)
    ValueError: operation forbidden on released memoryview object

This occurs due to an API break in the Python bindings. The
`Gst.Memory.map()` previously returned a copy of the audio data, but
it now returns a `memoryview()` instance pointing directly to the
memory. Since this is only valid while the Gst.Memory is mapped, we
need to manually copy it into a bytes() object.

The relevant GStreamer change is:
https://gitlab.freedesktop.org/gstreamer/gst-python/-/commit/fecfe451a7566740960d87da8a177f8a776f6137

Fixes https://github.com/beetbox/pyacoustid/issues/61