### PR TITLE
set default block size in FFmpegAudioFile to io.DEFAULT_BUFFER_SIZE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install ffmpeg
-        run: sudo apt install -y ffmpeg
+        run: sudo apt install -y --no-install-recommends ffmpeg
       - name: Install tox and any other packages
         run: pip install tox
       - name: Run tox

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ Version History
 3.0.0
   Drop support for Python 2 and older versions of Python 3. The library now
   requires Python 3.6+.
+  Increase default block size in FFmpegAudioFile to get slightly faster file reading.
 
 2.1.9
   Work correctly with GStreamer 1.18 and later (thanks to @ssssam).

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import threading
 import time
+from io import DEFAULT_BUFFER_SIZE
 
 from .exceptions import DecodeError
 
@@ -120,7 +121,7 @@ windows_error_mode_lock = threading.Lock()
 
 class FFmpegAudioFile:
     """An audio file decoded by the ffmpeg command-line utility."""
-    def __init__(self, filename, block_size=4096):
+    def __init__(self, filename, block_size=DEFAULT_BUFFER_SIZE):
         # On Windows, we need to disable the subprocess's crash dialog
         # in case it dies. Passing SEM_NOGPFAULTERRORBOX to SetErrorMode
         # disables this behavior.


### PR DESCRIPTION
To get slightly faster reads. on many systems this will now be 8192 bytes.

As discussed in #113.