### PR TITLE
Backend cache

### DIFF
--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -69,8 +69,7 @@ def available_backends(flush_cache=False):
     If the parameter `flush_cache` is set to `True`, then the cache
     will be flushed and the backend list will be reconstructed.
     """
-    global BACKENDS
-    if flush:
+    if flush_cache:
         BACKENDS.clear()
 
     if BACKENDS:

--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -59,9 +59,22 @@ def _mad_available():
     else:
         return True
 
+# A place to store available backends
+BACKENDS = []
 
-def available_backends():
-    """Returns a list of backends that are available on this system."""
+def available_backends(flush_cache=False):
+    """Returns a list of backends that are available on this system.
+
+    The list of backends is cached after the first call.
+    If the parameter `flush_cache` is set to `True`, then the cache
+    will be flushed and the backend list will be reconstructed.
+    """
+    global BACKENDS
+    if flush:
+        BACKENDS.clear()
+
+    if BACKENDS:
+        return BACKENDS
 
     # Standard-library WAV and AIFF readers.
     from . import rawread
@@ -86,7 +99,10 @@ def available_backends():
     if ffdec.available():
         result.append(ffdec.FFmpegAudioFile)
 
-    return result
+    # Cache the backends we found
+    BACKENDS.extend(result)
+
+    return BACKENDS
 
 
 def audio_open(path, backends=None):

--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -69,10 +69,8 @@ def available_backends(flush_cache=False):
     If the parameter `flush_cache` is set to `True`, then the cache
     will be flushed and the backend list will be reconstructed.
     """
-    if flush_cache:
-        BACKENDS.clear()
 
-    if BACKENDS:
+    if BACKENDS and not flush_cache:
         return BACKENDS
 
     # Standard-library WAV and AIFF readers.
@@ -99,7 +97,7 @@ def available_backends(flush_cache=False):
         result.append(ffdec.FFmpegAudioFile)
 
     # Cache the backends we found
-    BACKENDS.extend(result)
+    BACKENDS[:] = result
 
     return BACKENDS
 


### PR DESCRIPTION
Implements #125 - caches available backends after the first call.

I figured this was an easy enough patch that I'd just make the PR anyway.

I also added an option to flush the cache, in case for some reason, dependencies have changed in-flight.