### PR TITLE
Add common base class for all audio file types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ Version History
   requires Python 3.6+.
   Increase default block size in FFmpegAudioFile to get slightly faster file reading.
   Cache backends for faster lookup (thanks to @bmcfee).
+  Audio file classes now inherit from a common base ``AudioFile`` class.
 
 2.1.9
   Work correctly with GStreamer 1.18 and later (thanks to @ssssam).

--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -17,6 +17,7 @@
 from . import ffdec
 from .exceptions import DecodeError, NoBackendError
 from .version import version as __version__  # noqa
+from .base import AudioFile  # noqa
 
 
 def _gst_available():

--- a/audioread/base.py
+++ b/audioread/base.py
@@ -1,0 +1,18 @@
+# This file is part of audioread.
+# Copyright 2021, Adrian Sampson.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+
+class AudioFile:
+    """The base class for all audio file types.
+    """

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -25,6 +25,7 @@ import time
 from io import DEFAULT_BUFFER_SIZE
 
 from .exceptions import DecodeError
+from .base import AudioFile
 
 COMMANDS = ('ffmpeg', 'avconv')
 
@@ -118,7 +119,7 @@ def available():
 windows_error_mode_lock = threading.Lock()
 
 
-class FFmpegAudioFile:
+class FFmpegAudioFile(AudioFile):
     """An audio file decoded by the ffmpeg command-line utility."""
     def __init__(self, filename, block_size=DEFAULT_BUFFER_SIZE):
         # On Windows, we need to disable the subprocess's crash dialog

--- a/audioread/gstdec.py
+++ b/audioread/gstdec.py
@@ -57,6 +57,7 @@ import queue
 from urllib.parse import quote
 
 from .exceptions import DecodeError
+from .base import AudioFile
 
 QUEUE_SIZE = 10
 BUFFER_SIZE = 10
@@ -141,7 +142,7 @@ class MainLoopThread(threading.Thread):
 
 # The decoder.
 
-class GstAudioFile:
+class GstAudioFile(AudioFile):
     """Reads raw audio data from any audio file that Gstreamer
     knows how to decode.
 

--- a/audioread/macca.py
+++ b/audioread/macca.py
@@ -20,6 +20,7 @@ import os
 import sys
 
 from .exceptions import DecodeError
+from .base import AudioFile
 
 
 # CoreFoundation and CoreAudio libraries along with their function
@@ -184,7 +185,7 @@ class AudioBufferList(ctypes.Structure):
 
 # Main functionality.
 
-class ExtAudioFile:
+class ExtAudioFile(AudioFile):
     """A CoreAudio "extended audio file". Reads information and raw PCM
     audio data from any file that CoreAudio knows how to decode.
 

--- a/audioread/maddec.py
+++ b/audioread/maddec.py
@@ -16,13 +16,14 @@
 import mad
 
 from . import DecodeError
+from .base import AudioFile
 
 
 class UnsupportedError(DecodeError):
     """The file is not readable by MAD."""
 
 
-class MadAudioFile:
+class MadAudioFile(AudioFile):
     """MPEG audio file decoder using the MAD library."""
     def __init__(self, filename):
         self.fp = open(filename, 'rb')

--- a/audioread/rawread.py
+++ b/audioread/rawread.py
@@ -20,6 +20,7 @@ import sunau
 import wave
 
 from .exceptions import DecodeError
+from .base import AudioFile
 
 # Produce two-byte (16-bit) output samples.
 TARGET_WIDTH = 2
@@ -50,7 +51,7 @@ def byteswap(s):
     return b''.join(parts)
 
 
-class RawAudioFile:
+class RawAudioFile(AudioFile):
     """An AIFF, WAV, or Au file that can be read by the Python standard
     library modules ``wave``, ``aifc``, and ``sunau``.
     """


### PR DESCRIPTION
Following up on #125, this adds a simple (dummy) base class `audioread.AudioFile` from which all the various backends' audio file classes inherit. The class has no methods, so it's not very duck-typey, but we don't currently have any shared functionality to actually move there. We could revisit this some later time.

It would be great to get @bmcfee's eyes on this if it's not too much trouble!