### PR TITLE
Fix deadlock in ffdec.available()

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -110,7 +110,7 @@ def available():
     except OSError:
         return False
     else:
-        proc.wait()
+        proc.communicate()
         return proc.returncode == 0
 
 


### PR DESCRIPTION
Fixes #130 by changing `wait()` to `communicate()` to avoid deadlock

See https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait for context.