### PR TITLE
add support for os.PathLike filenames in macca.py

### DIFF
--- a/audioread/macca.py
+++ b/audioread/macca.py
@@ -137,9 +137,9 @@ class CFObject:
 
 class CFURL(CFObject):
     def __init__(self, filename):
+        filename = os.path.abspath(os.path.expanduser(filename))
         if not isinstance(filename, bytes):
             filename = filename.encode(sys.getfilesystemencoding())
-        filename = os.path.abspath(os.path.expanduser(filename))
         url = _corefoundation.CFURLCreateFromFileSystemRepresentation(
             0, filename, len(filename), False
         )


### PR DESCRIPTION
Closes #138 

This PR makes use of the fact that `os.path.expanduser` & `os.path.abspath` call [`os.fspath(path)`](https://docs.python.org/3.8/library/os.html#os.fspath) to resolve PathLike objects.