### PR TITLE
Enhancement: Custom FFmpeg Path Support for FFMPEG Backend

### DIFF
--- a/audioread/__init__.py
+++ b/audioread/__init__.py
@@ -105,7 +105,7 @@ def available_backends(flush_cache=False):
     return BACKENDS
 
 
-def audio_open(path, backends=None):
+def audio_open(path, backends=None,ffmpeg_path=None):
     """Open an audio file using a library that is available on this
     system.
 
@@ -124,6 +124,8 @@ def audio_open(path, backends=None):
 
     for BackendClass in backends:
         try:
+            if BackendClass is ffdec.FFmpegAudioFile:
+                return BackendClass(path,ffmpeg_path=ffmpeg_path)
             return BackendClass(path)
         except DecodeError:
             pass


### PR DESCRIPTION
This pull request enhances the audioread library by introducing custom FFmpeg path support for the FFMPEG backend. With this enhancement, users can specify a custom path to the FFmpeg executable, enabling greater flexibility and compatibility across different systems.

Key Changes:

Added functionality to specify a custom path to the FFmpeg executable for the FFMPEG backend.
Improved compatibility by handling platform-specific differences in FFmpeg executable paths (e.g., .exe extension on Windows).

Example use with change:
`with audioread.audio_open(os.path.realpath(path), backends=backends,ffmpeg_path=ffmpeg_path) as input_file:
        sr_native = input_file.samplerate
        n_channels = input_file.channels`

We can ignore the `ffmpeg_path` argument if doesn't have custom cause it detect it from environment variables `PATH`.
So now it is compatible with both with `ffmpeg_path` and without it both at the same time.