### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
     'License :: OSI Approved :: MIT License',
 ]
 license = {file = "LICENSE"}
+dependencies = [
+    "standard-aifc; python_version >= '3.13'",
+    "standard-sunau; python_version >= '3.13'",
+]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Python core removed modules `aifc` and `sunau` in 3.13 as part of PEP-594 https://peps.python.org/pep-0594/
This change adds `standard-aifc` and `standard-sunau` as dependencies for python 3.13 and above.  These are forks of the modules that had previously been in the python core.

Also updates the test config to run against python 3.12 and python 3.13

Fixes #144