### PR TITLE
legacy dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ currently supports:
 - `Core Audio`_ on Mac OS X via `ctypes`_. (PyObjC not required.)
 - `MAD`_ via the `pymad`_ bindings.
 - `FFmpeg`_ or `Libav`_ via its command-line interface.
-- The standard library `wave`_, `aifc`_, and `sunau`_ modules (for
-  uncompressed audio formats).
+- The standard library `wave`_ module (for
+  uncompressed audio formats).  Legacy formats `aifc`_ and `sunau`_ are also optionally supported, see the note below.
 
 .. _Gstreamer: http://gstreamer.freedesktop.org/
 .. _gst-python: http://gstreamer.freedesktop.org/modules/gst-python.html
@@ -72,6 +72,18 @@ that you have a broken installation of `FFmpeg`_. To check, try typing
 ``ffmpeg -version`` in your shell. If that gives you an error, try installing
 FFmpeg with your OS's package manager (e.g., apt or yum) or `using Conda
 <https://anaconda.org/conda-forge/ffmpeg>`_.
+
+Legacy formats
+--------------
+The `aifc`_ and `sunau`_ modules were deprecated and removed from the standard
+Python distribution in version 3.13.
+Support for `aifc` and `sunau` formats is still available through `deadlib`_.
+To install audioread with continued support for these formats, you can
+use the following command::
+
+    python -m pip install audioread[legacy]
+
+.. _deadlib: https://github.com/youknowone/python-deadlib
 
 Version History
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Adrian Sampson", email = "adrian@radbox.org"}
 ]
 readme = "README.rst"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dynamic = ["version", "description"]
 urls.Home = "https://github.com/beetbox/audioread"
 classifiers = [
@@ -19,6 +19,8 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'License :: OSI Approved :: MIT License',
 ]
 license = {file = "LICENSE"}
@@ -26,4 +28,8 @@ license = {file = "LICENSE"}
 [project.optional-dependencies]
 test = [
     "tox"
+]
+legacy = [
+    "standard-aifc; python_version >= '3.13'",
+    "standard-sunau; python_version >= '3.13'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ authors = [
 ]
 readme = "README.rst"
 requires-python = ">=3.8"
+requires = [
+    "audioop-lts; python_version >= '3.13'"
+]
 dynamic = ["version", "description"]
 urls.Home = "https://github.com/beetbox/audioread"
 classifiers = [


### PR DESCRIPTION
This PR is similar to #145, but implements the alternative strategy described in #144 of making deprecated dependencies optional on python 3.13.

This isn't necessarily meant to supersede #145, just to provide an alternative implementation that's ready to go in case @sampsyo wants to go this route instead.

Summary of changes:

- Added `audioop-lts` as a hard requirement on `python >= 3.13`.  This is necessary for the `lin2lin` function used in all rawread paths.
- Reorganized the codec ordering in RawRead so that wave (still supported) is first, followed by aiff and au.
- Implemented soft failure for aifc and sunau modules, issuing a warning if the module is missing.
- Added `legacy` mode installation which includes dependencies for `standard-aifc` and `standard-sunau` if `python >= 3.13`.  Can be invoked by `python -m pip install audioread[legacy]`.
- Updated documentation (README) to reflect the status of deprecated packages and legacy install instructions.
